### PR TITLE
fixed issue with WithCheck() not logging the error message

### DIFF
--- a/src/NBomber.Http/Http.fs
+++ b/src/NBomber.Http/Http.fs
@@ -82,7 +82,7 @@ module internal HttpUtils =
         if req.Check.IsSome then
             let! result = req.Check.Value(response)
             if result.IsError then
-                return Response.fail(statusCode = result.StatusCode, sizeBytes = origResSize)
+                return Response.fail(error = result.ErrorMessage, statusCode = result.StatusCode, sizeBytes = origResSize)
             else
                 return Response.ok(result.Payload, statusCode = result.StatusCode, sizeBytes = origResSize)
         else


### PR DESCRIPTION
Fix to https://github.com/PragmaticFlow/NBomber/issues/426

WithCheck was missing mapping for error message when returning Response.